### PR TITLE
PCT2075 additions

### DIFF
--- a/impisc/i2c/devices/pct2075.py
+++ b/impisc/i2c/devices/pct2075.py
@@ -2,6 +2,8 @@
 Defines a class for interfacing with a PCT2075 I2C temperature sensor.
 """
 
+from typing import Literal
+
 from .device import GenericDevice, Register, int_to_twos_complement
 
 
@@ -81,7 +83,7 @@ class PCT2075(GenericDevice):
             self.write_block_data("conf", self.conf_register | 0b00000001)
 
     @property
-    def os_mode(self) -> str:
+    def os_mode(self) -> Literal["comparator", "interrupt"]:
         """The current OS (overtemperature shutdown) operation mode.
         Either "comparator" or "interrupt".
         """
@@ -89,7 +91,7 @@ class PCT2075(GenericDevice):
         return "interrupt" if bit else "comparator"
 
     @os_mode.setter
-    def os_mode(self, mode: str):
+    def os_mode(self, mode: Literal["comparator", "interrupt"]):
         """Set the OS operation mode to either "comparator" or "interrupt"."""
         match mode:
             case "comparator":
@@ -97,13 +99,13 @@ class PCT2075(GenericDevice):
             case "interrupt":
                 self.write_block_data("conf", self.conf_register | 0b00000010)
             case _:
-                raise ValueError(
+                raise ValueError(  # pyright: ignore[reportUnreachable]
                     f"Provided OS mode ({mode}) is invalid; "
                     + 'must either be "comparator" or "interrupt"'
                 )
 
     @property
-    def os_polarity(self) -> str:
+    def os_polarity(self) -> Literal["low", "high"]:
         """The current OS (overtemperature shutdown) polarity.
         Either active "low" or "high".
         """
@@ -111,7 +113,7 @@ class PCT2075(GenericDevice):
         return "high" if bit else "low"
 
     @os_polarity.setter
-    def os_polarity(self, polarity: str):
+    def os_polarity(self, polarity: Literal["low", "high"]):
         """Set the OS (overtemperature shutdown) polarity to either "low" or "high"."""
         match polarity:
             case "low":
@@ -119,7 +121,7 @@ class PCT2075(GenericDevice):
             case "high":
                 self.write_block_data("conf", self.conf_register | 0b00000100)
             case _:
-                raise ValueError(
+                raise ValueError(  # pyright: ignore[reportUnreachable]
                     f"Provided OS polarity ({polarity}) is invalid; "
                     + 'must either be "low" or "high"'
                 )

--- a/impisc/i2c/tests/test_pct2075.py
+++ b/impisc/i2c/tests/test_pct2075.py
@@ -57,11 +57,8 @@ def test_idle():
             f"Expected {expected} but got {device.idle_time} instead (rounding error?)"
         )
     for value in [0.01, 3.11]:
-        try:
+        with pytest.raises(ValueError):
             device.idle_time = value
-            raise RuntimeError("SHOULD NOT REACH HERE!!!")
-        except ValueError:
-            pass
 
 
 def test_os_mode():


### PR DESCRIPTION
Major additions to PCT2075 control:

- Added ability to wakeup/shutdown the device
- Added ability to set the overtemperature shutdown parameters (mode, polarity, threshold, hysteresis, queue)
- Added ability to set the idle time

Tests were added for all of these functionalities.