### PR TITLE
Lock voltage measurements

### DIFF
--- a/processes/health_monitor
+++ b/processes/health_monitor
@@ -25,11 +25,14 @@ cadence_seconds = int(os.getenv("HEALTH_CADENCE"))
 generator_type: TypeAlias = Callable[[], tuple[bool, Any]]
 
 
+# We need to lock the i2c voltage reading so we don't
+# end up with garbage values.
+voltage_lock = threading.Lock()
 MAX11617_CHANNELS: dict[str, Literal[0, 1, 2, 3, 4, 5, 6, 7, 8]] = {
     "-SIPM": 0,
     "-BUBBA": 1,
-    "+CREMAT": 2,
-    "-CREMAT": 3,
+    "+CREMAT": NotImplemented,
+    "-CREMAT": NotImplemented,
     "+SIPM": 4,
     "DAQBOX": 5,
     "+BUBBA": 6,
@@ -51,13 +54,25 @@ TIMEOUTS.update(
 
 def main():
     generators: list[tuple[str, generator_type]] = [
-        ("cm4_volts", measure_pi_voltage),
-        ("heater_volts", measure_heater_volts),
-        ("daqbox_volts", measure_daqbox_volts),
-        ("sipm_preamp_pos_volts", measure_preamp_pos),
-        ("sipm_preamp_neg_volts", measure_preamp_neg),
-        ("bubba_input_pos_volts", measure_bubba_pos_input),
-        ("bubba_input_neg_volts", measure_bubba_neg_input),
+        ("cm4_volts", lambda: measure_power_line(MAX11617_CHANNELS["CM4"])),
+        ("heater_volts", lambda: measure_power_line(MAX11617_CHANNELS["HEATER"])),
+        ("daqbox_volts", lambda: measure_power_line(MAX11617_CHANNELS["DAQBOX"])),
+        (
+            "sipm_preamp_pos_volts",
+            lambda: measure_power_line(MAX11617_CHANNELS["+SIPM"]),
+        ),
+        (
+            "sipm_preamp_neg_volts",
+            lambda: measure_power_line(MAX11617_CHANNELS["-SIPM"]),
+        ),
+        (
+            "bubba_input_pos_volts",
+            lambda: measure_power_line(MAX11617_CHANNELS["+BUBBA"]),
+        ),
+        (
+            "bubba_input_neg_volts",
+            lambda: measure_power_line(MAX11617_CHANNELS["-BUBBA"]),
+        ),
         ("bubba_output_volts", measure_bubba_output),
         ("bubba_wiper", measure_bubba_wiper),
         ("power_line_statuses", measure_toggle_byte),
@@ -116,50 +131,16 @@ def measure(func: generator_type, results: list[tuple[bool, Any]], index: int) -
 
 
 def measure_power_line(channel: Literal[0, 1, 2, 3, 4, 5, 6, 7, 8]) -> tuple[bool, int]:
-    """Measure the voltage (in centivolts) on the specified channel on the MAX11617."""
-    try:
-        MAX11617: max11617.MAX11617 = max11617.MAX11617(1, 0x35)
-        MAX11617.reference = "internal"
-        MAX11617.scan = 3
-        return False, int(MAX11617.read_conversion(which=channel) * 100)
-    except Exception as e:
-        logging.log_warning(f"Could not read channel {channel} from MAX11617.\n{e}")
-    return True, -1  # TODO: change null value to something else; we're using uint8
-
-
-def measure_pi_voltage() -> tuple[bool, int]:
-    """Measure the voltage (cV) powering the CM4."""
-    return measure_power_line(MAX11617_CHANNELS["CM4"])
-
-
-def measure_heater_volts() -> tuple[bool, int]:
-    """Measure the heater voltage."""
-    return measure_power_line(MAX11617_CHANNELS["HEATER"])
-
-
-def measure_daqbox_volts() -> tuple[bool, int]:
-    """Measure the DAQBOX voltage."""
-    return measure_power_line(MAX11617_CHANNELS["DAQBOX"])
-
-
-def measure_preamp_pos() -> tuple[bool, int]:
-    """Measure the positive voltage (cV) powering the SiPM boards."""
-    return measure_power_line(MAX11617_CHANNELS["+SIPM"])
-
-
-def measure_preamp_neg() -> tuple[bool, int]:
-    """Measure the negative voltage (cV) powering the SiPM boards."""
-    return measure_power_line(MAX11617_CHANNELS["-SIPM"])
-
-
-def measure_bubba_pos_input() -> tuple[bool, int]:
-    """Measure the positive voltage (cV) powering the bias board."""
-    return measure_power_line(MAX11617_CHANNELS["+BUBBA"])
-
-
-def measure_bubba_neg_input() -> tuple[bool, int]:
-    """Measure the negative voltage (cV) powering the bias board."""
-    return measure_power_line(MAX11617_CHANNELS["-BUBBA"])
+    with voltage_lock:
+        """Measure the voltage (in centivolts) on the specified channel on the MAX11617."""
+        try:
+            MAX11617: max11617.MAX11617 = max11617.MAX11617(1, 0x35)
+            MAX11617.reference = "internal"
+            MAX11617.scan = 3
+            return False, int(MAX11617.read_conversion(which=channel) * 100)
+        except Exception as e:
+            logging.log_warning(f"Could not read channel {channel} from MAX11617.\n{e}")
+    return True, -1
 
 
 def measure_bubba_output() -> tuple[bool, int]:
@@ -181,21 +162,19 @@ def measure_bubba_output() -> tuple[bool, int]:
 
 def measure_toggle_byte() -> tuple[bool, int]:
     """Measure the byte indicating the status of all the GPIO toggles."""
+    bad = (True, -1)
     try:
         res = subprocess.run(["power_status"], shell=True, capture_output=True)
         if res.stderr:
             logging.log_error(
                 "Problem reading power toggle status byte: {res.stderr.decode('utf-8')}."
             )
-            return True, -1
+            return bad
         status_byte = int(res.stdout.decode("utf-8").strip(), base=2)
         return False, status_byte
     except Exception as e:
         logging.log_error(f"Problem reading toggle statuses: {type(e)} --> {e.args}")
-    return True, 0
-
-
-wiper_issues = 0
+    return bad
 
 
 def measure_bubba_wiper() -> tuple[bool, int]:
@@ -207,11 +186,10 @@ def measure_bubba_wiper() -> tuple[bool, int]:
         value = ISL22317.wiper
         ISL22317.awake = initial_status
         return False, value
-    except IOError as e:
-        global wiper_issues
-        if wiper_issues % 100 == 0:
-            logging.log_warning(f"Cannot contact ISL22317; is it on?\n{e}")
-        wiper_issues += 1
+    except IOError:
+        # If Bubba is off, we will get an error,
+        # so just ignore it
+        pass
     return True, -1
 
 
@@ -223,7 +201,6 @@ def disk_usage(partition: str) -> int:
     )
     if res.stderr:
         raise ValueError(f"Error running command: {res.stderr.decode('utf-8')}")
-    # 10 MiB chunks
     return int(res.stdout.decode("utf-8").split("\n")[1].strip())
 
 
@@ -236,7 +213,6 @@ def measure_os_disk_usage() -> tuple[bool, int]:
     except Exception as e:
         logging.log_error(f"Problem getting disk usage: {type(e)} --> {e.args}")
 
-    # Failed to get disk usage; indicate missing
     return True, -1
 
 
@@ -247,7 +223,6 @@ def measure_data_disk_usage() -> tuple[bool, int]:
     except Exception as e:
         logging.log_error(f"Problem getting disk usage: {type(e)} --> {e.args}")
 
-    # Failed to get disk usage; indicate missing
     return True, -1
 
 

--- a/processes/health_monitor
+++ b/processes/health_monitor
@@ -61,18 +61,12 @@ def main():
             "sipm_preamp_pos_volts",
             lambda: measure_power_line(MAX11617_CHANNELS["+SIPM"]),
         ),
-        (
-            "sipm_preamp_neg_volts",
-            lambda: measure_power_line(MAX11617_CHANNELS["-SIPM"]),
-        ),
+        ("sipm_preamp_neg_volts", lambda: measure_negative_voltage("-SIPM")),
         (
             "bubba_input_pos_volts",
             lambda: measure_power_line(MAX11617_CHANNELS["+BUBBA"]),
         ),
-        (
-            "bubba_input_neg_volts",
-            lambda: measure_power_line(MAX11617_CHANNELS["-BUBBA"]),
-        ),
+        ("bubba_input_neg_volts", lambda: measure_negative_voltage("-BUBBA")),
         ("bubba_output_volts", measure_bubba_output),
         ("bubba_wiper", measure_bubba_wiper),
         ("power_line_statuses", measure_toggle_byte),
@@ -128,6 +122,20 @@ def main():
 def measure(func: generator_type, results: list[tuple[bool, Any]], index: int) -> None:
     """Helper function for threading purposes."""
     results[index] = func()
+
+
+def measure_negative_voltage(chan_id: str) -> tuple[bool, int]:
+    """We need to scale the negative voltages by an ad-hoc factor due to
+    resistive inverting op amp gain. So, do that here before returning the 'true' value
+    of the voltage measurement."""
+    missing, value = measure_power_line(MAX11617_CHANNELS[chan_id])
+    if missing:
+        # Bad things happened during the measurement;
+        # don't do more calculations
+        return missing, value
+
+    scales = {"-SIPM": 0.8, "-BUBBA": 0.99992850511}
+    return missing, int(value * scales[chan_id])
 
 
 def measure_power_line(channel: Literal[0, 1, 2, 3, 4, 5, 6, 7, 8]) -> tuple[bool, int]:


### PR DESCRIPTION
Add thread locks for voltage measurements to avoid race conditions on the i2c bus