### PR TITLE
Make `set_bias` arg positional

### DIFF
--- a/scripts/set_bias
+++ b/scripts/set_bias
@@ -44,11 +44,10 @@ def set_voltage(voltage: float):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-v", type=float, help="desired bias voltage, in volts", required=True
+        "voltage", type=float, help="desired bias voltage, in volts"
     )
     arg = parser.parse_args()
-    voltage = arg.v
-    set_voltage(voltage)
+    set_voltage(arg.voltage)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It bothered me that there is only one argument (which is required) in `set_bias` and it required the `-v` flag. This changes the argument to be positional, so the flag is not needed.

Example usage to set the bias to 46.5 volts: `set_bias 46.5`
