### PR TITLE
Rebinner related updates

### DIFF
--- a/rust/src/bin/daqbox-rebinner.rs
+++ b/rust/src/bin/daqbox-rebinner.rs
@@ -112,7 +112,7 @@ fn main() {
         accumulated = (accumulated + 1) % spectra_per_packet;
         if accumulated == 0 {
             // Enough space for timestamp plus summed bins
-            let mut packet: Vec<u8> = Vec::with_capacity(TIME_INFO_SZ + NUM_CHAN * num_bins);
+            let mut packet: Vec<u8> = Vec::with_capacity(TIME_INFO_SZ + NUM_CHAN * num_bins * 4);
             // The first 5 bytes are the most recent timestamp
             // and DAQBOX frame number
             packet.extend(&buf[..TIME_INFO_SZ]);

--- a/scripts/set_science_bias
+++ b/scripts/set_science_bias
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-set_bias -v 38
+set_bias 38


### PR DESCRIPTION
- Update the number of bytes reserved at one stage in the rebinner
- Change the `set_science_bias` script to comply with the new `set_bias` syntax

**Importantly**: the rebinner works fine; on the ground we need to remember that the output numbers are `u32`, NOT the DAQBOX native `u16`.