### PR TITLE
Add package for `hwclock` command

### DIFF
--- a/deployment/install_required_programs
+++ b/deployment/install_required_programs
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt update
-sudo apt install -y networkd-dispatcher stress-ng libgpiod-dev cmake build-essential python3-dev
+sudo apt install -y networkd-dispatcher stress-ng libgpiod-dev cmake build-essential python3-dev util-linux-extra
 
 # Rust installation: put cargo/rustup on the data disk,
 # because the OS disk is tiny


### PR DESCRIPTION
We need the `hwclock` command to sync the RTC with the time it gets from the internet. `hwclock` comes from `util-linux-extra`.