### PR TITLE
switch to flask

### DIFF
--- a/ground_station/processes/command_forwarder
+++ b/ground_station/processes/command_forwarder
@@ -4,8 +4,6 @@ Listens for commands submitted through Grafana and forwards them to IMPISH.
 """
 
 import argparse
-import json
-import os
 import socket
 import struct
 
@@ -14,10 +12,6 @@ from dataclasses import dataclass
 from flask import Flask, request
 from flask_cors import CORS
 from impisc import logging
-
-
-app = Flask(__name__)
-CORS(app)
 
 
 @dataclass
@@ -75,15 +69,16 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-args = parse_args()
-forwarder = Forwarder(args.bind_port, args.impish_ip, args.impish_port)
-
-
-@app.post('/receive')
-def receive():
-    forwarder.forward(request.get_json()["command"])
-    return "command received"
-
-
 if __name__ == "__main__":
+    app = Flask(__name__)
+    CORS(app)
+
+    args = parse_args()
+    forwarder = Forwarder(args.bind_port, args.impish_ip, args.impish_port)
+
+    @app.post("/receive")
+    def receive():
+        forwarder.forward(request.get_json()["command"])
+        return "command received"
+
     app.run("0.0.0.0", port=args.http_port)

--- a/ground_station/processes/command_forwarder
+++ b/ground_station/processes/command_forwarder
@@ -81,4 +81,5 @@ if __name__ == "__main__":
         forwarder.forward(request.get_json()["command"])
         return "command received"
 
-    app.run("0.0.0.0", port=args.http_port)
+    from waitress import serve
+    serve(app, host="0.0.0.0", port=args.http_port)

--- a/ground_station/processes/command_forwarder
+++ b/ground_station/processes/command_forwarder
@@ -5,13 +5,19 @@ Listens for commands submitted through Grafana and forwards them to IMPISH.
 
 import argparse
 import json
+import os
 import socket
 import struct
 
 from dataclasses import dataclass
-from http.server import BaseHTTPRequestHandler, HTTPServer
 
+from flask import Flask, request
+from flask_cors import CORS
 from impisc import logging
+
+
+app = Flask(__name__)
+CORS(app)
 
 
 @dataclass
@@ -33,39 +39,6 @@ class Forwarder:
             f"Sending command {command} to {self.forward_ip}:{self.forward_port}"
         )
         _ = sock.sendto(self.packetize(command), (self.forward_ip, self.forward_port))
-
-
-class Server(HTTPServer):
-    def __init__(self, address, request_handler, forwarder: Forwarder):
-        super().__init__(address, request_handler)
-        self.forwarder: Forwarder = forwarder
-
-
-class RequestHandler(BaseHTTPRequestHandler):
-    def do_POST(self):
-        content_length = int(self.headers["Content-Length"])
-        data: bytes = self.rfile.read(content_length)
-        decoded: dict[str, str] = json.loads(data.decode("utf-8"))
-        logging.log_info(f"Received command data: {decoded}")
-        self.send_response(200)
-        self.end_headers()
-        _ = self.wfile.write(b"POST received")
-        self.server.forwarder.forward(decoded["command"])
-
-    def do_OPTIONS(self):
-        self.send_response(200)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
-        self.end_headers()
-
-
-def main() -> None:
-
-    args = parse_args()
-    forwarder = Forwarder(args.bind_port, args.impish_ip, args.impish_port)
-    server = Server(("0.0.0.0", args.http_port), RequestHandler, forwarder)
-    server.serve_forever()
 
 
 def parse_args() -> argparse.Namespace:
@@ -102,5 +75,15 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+args = parse_args()
+forwarder = Forwarder(args.bind_port, args.impish_ip, args.impish_port)
+
+
+@app.post('/receive')
+def receive():
+    forwarder.forward(request.get_json()["command"])
+    return "command received"
+
+
 if __name__ == "__main__":
-    main()
+    app.run("0.0.0.0", port=args.http_port)

--- a/ground_station/pyproject.toml
+++ b/ground_station/pyproject.toml
@@ -13,7 +13,8 @@ name = "impish_monitor"
 dependencies = [
     "mysql-connector-python",
     "flask",
-    "flask_cors"
+    "flask_cors",
+    "waitress"
 ]
 
 [project.optional-dependencies]

--- a/ground_station/pyproject.toml
+++ b/ground_station/pyproject.toml
@@ -11,7 +11,9 @@ packages = [
 version = "0"
 name = "impish_monitor"
 dependencies = [
-    "mysql-connector-python"
+    "mysql-connector-python",
+    "flask",
+    "flask_cors"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Switch from the standard library's `http` to `flask` for managing the commanding. This is mainly so we can use `flask_cors` to handle the CORS business, which was resulting in weird errors with `http`.