### PR TITLE
fix recalibration step

### DIFF
--- a/scripts/recalibrate_daqbox
+++ b/scripts/recalibrate_daqbox
@@ -4,15 +4,20 @@
 Just recalibrate the DAQBOX baseline
 """
 
-import os
-import socket
 import sys
 import time
 
 from impisc.et_daqbox import daq_box_api as dbapi
 from impisc import logging
 
+cfg_file = "/data/config/daqbox_config.json"
+if len(sys.argv) > 1:
+    cfg_file = sys.argv[1]
+
+cfg = dbapi.DaqBoxConfig.from_file(cfg_file)
 iface = dbapi.DaqBoxInterface()
+iface.send(cfg.to_packet())
+
 logging.log_warning("recalibrate baseline (wait)")
 iface.recalibrate_baseline()
 time.sleep(10)

--- a/scripts/start_science_rebinner
+++ b/scripts/start_science_rebinner
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 # Don't rebin anything
-bins=""
 source /data/config/variables.env
-daqbox-rebinner $SCIENCE_REBINNER_PORT $SCIENCE_UDPCAP_PORT 1 "$bins"
+daqbox-rebinner $SCIENCE_REBINNER_PORT $SCIENCE_UDPCAP_PORT 1 "$SCIENCE_REBIN_BINS"


### PR DESCRIPTION
Load the DAQBOX config file before recalibration. if we don't do this, the baseline calibration step is messed up.