### PR TITLE
update recalibration with multi channel knowledge

### DIFF
--- a/scripts/recalibrate_daqbox
+++ b/scripts/recalibrate_daqbox
@@ -65,7 +65,7 @@ def sample_baseline(
 
     # The period right after a pulse is usually quiet,
     # at least at low count rates.
-    quiet_slice = slice(250, 300)
+    quiet_slice = slice(0, 40)
     medians = list()
     for _ in range(num_waveforms):
         wf_data = iface.recv()

--- a/scripts/start_science
+++ b/scripts/start_science
@@ -2,9 +2,12 @@
 
 source /data/config/variables.env
 
-turn_me_on="1 2 3 4 daqbox bias"
-for ch in $turn_me_on; do
-    toggle_power $ch on
+
+# Turn on the bias and daqbox and one preamp channel for initial
+# recalibration
+turn_me_on="3 daqbox bias"
+for t in $turn_me_on; do
+    toggle_power $t
 done
 
 # Wait for power to stabilize
@@ -17,10 +20,18 @@ sleep 10
 
 # Recalibrate the baseline before science begins
 recalibrate_daqbox
+
 if [ $? -ne 0 ]; then
     stop_science
     echo "<2> Failed to recalibrate DAQBOX after several attempts" >&2
     exit 1
 fi
+
+# Turn on the rest of the preamplifier channels
+turn_me_on="1 2 4"
+for t in $turn_me_on; do
+    toggle_power $t
+done
+sleep 1
 
 sudo systemctl start nominal-science.service


### PR DESCRIPTION
The science recalibration gives very weird/unpredictable results when performed on all four channels simultaneously. It seems like mixing scintillators causes particular issues.

So, just calibrate the baseline on a single channel, and apply that to all channels. This should be valid provided the detectors are at the same temperature, and have received the same dose of radiation to the SiPMs (crystalline structure damage).